### PR TITLE
Bump runtime to 42 and oomox to 1.14

### DIFF
--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -1,0 +1,632 @@
+[
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/adler/adler-1.0.2.crate",
+        "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+        "dest": "cargo/vendor/adler-1.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe\", \"files\": {}}",
+        "dest": "cargo/vendor/adler-1.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/adler32/adler32-1.2.0.crate",
+        "sha256": "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234",
+        "dest": "cargo/vendor/adler32-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234\", \"files\": {}}",
+        "dest": "cargo/vendor/adler32-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arrayref/arrayref-0.3.6.crate",
+        "sha256": "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544",
+        "dest": "cargo/vendor/arrayref-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayref-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.5.2.crate",
+        "sha256": "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b",
+        "dest": "cargo/vendor/arrayvec-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayvec-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.2.crate",
+        "sha256": "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6",
+        "dest": "cargo/vendor/arrayvec-0.7.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayvec-0.7.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.13.0.crate",
+        "sha256": "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd",
+        "dest": "cargo/vendor/base64-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-1.3.2.crate",
+        "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+        "dest": "cargo/vendor/bitflags-1.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-1.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.9.1.crate",
+        "sha256": "cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc",
+        "dest": "cargo/vendor/bytemuck-1.9.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck-1.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.0.crate",
+        "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+        "dest": "cargo/vendor/cfg-if-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-if-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/color_quant/color_quant-1.1.0.crate",
+        "sha256": "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b",
+        "dest": "cargo/vendor/color_quant-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b\", \"files\": {}}",
+        "dest": "cargo/vendor/color_quant-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.3.2.crate",
+        "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
+        "dest": "cargo/vendor/crc32fast-1.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d\", \"files\": {}}",
+        "dest": "cargo/vendor/crc32fast-1.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/data-url/data-url-0.1.1.crate",
+        "sha256": "3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193",
+        "dest": "cargo/vendor/data-url-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193\", \"files\": {}}",
+        "dest": "cargo/vendor/data-url-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/deflate/deflate-1.0.0.crate",
+        "sha256": "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f",
+        "dest": "cargo/vendor/deflate-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f\", \"files\": {}}",
+        "dest": "cargo/vendor/deflate-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/flate2/flate2-1.0.24.crate",
+        "sha256": "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6",
+        "dest": "cargo/vendor/flate2-1.0.24"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6\", \"files\": {}}",
+        "dest": "cargo/vendor/flate2-1.0.24",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/float-cmp/float-cmp-0.9.0.crate",
+        "sha256": "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4",
+        "dest": "cargo/vendor/float-cmp-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4\", \"files\": {}}",
+        "dest": "cargo/vendor/float-cmp-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fontconfig-parser/fontconfig-parser-0.5.0.crate",
+        "sha256": "82cea2adebf32a9b104b8ffb308b5fb3b456f04cc76c294c3c85025c8a5d75f4",
+        "dest": "cargo/vendor/fontconfig-parser-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"82cea2adebf32a9b104b8ffb308b5fb3b456f04cc76c294c3c85025c8a5d75f4\", \"files\": {}}",
+        "dest": "cargo/vendor/fontconfig-parser-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fontdb/fontdb-0.9.1.crate",
+        "sha256": "122fa73a5566372f9df09768a16e8e3dad7ad18abe07835f1f0b71f84078ba4c",
+        "dest": "cargo/vendor/fontdb-0.9.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"122fa73a5566372f9df09768a16e8e3dad7ad18abe07835f1f0b71f84078ba4c\", \"files\": {}}",
+        "dest": "cargo/vendor/fontdb-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gif/gif-0.11.3.crate",
+        "sha256": "c3a7187e78088aead22ceedeee99779455b23fc231fe13ec443f99bb71694e5b",
+        "dest": "cargo/vendor/gif-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3a7187e78088aead22ceedeee99779455b23fc231fe13ec443f99bb71694e5b\", \"files\": {}}",
+        "dest": "cargo/vendor/gif-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jpeg-decoder/jpeg-decoder-0.2.6.crate",
+        "sha256": "9478aa10f73e7528198d75109c8be5cd7d15fb530238040148d5f9a22d4c5b3b",
+        "dest": "cargo/vendor/jpeg-decoder-0.2.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9478aa10f73e7528198d75109c8be5cd7d15fb530238040148d5f9a22d4c5b3b\", \"files\": {}}",
+        "dest": "cargo/vendor/jpeg-decoder-0.2.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/kurbo/kurbo-0.8.3.crate",
+        "sha256": "7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449",
+        "dest": "cargo/vendor/kurbo-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449\", \"files\": {}}",
+        "dest": "cargo/vendor/kurbo-0.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libc/libc-0.2.126.crate",
+        "sha256": "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836",
+        "dest": "cargo/vendor/libc-0.2.126"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.126",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/log/log-0.4.17.crate",
+        "sha256": "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e",
+        "dest": "cargo/vendor/log-0.4.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e\", \"files\": {}}",
+        "dest": "cargo/vendor/log-0.4.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/matches/matches-0.1.9.crate",
+        "sha256": "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f",
+        "dest": "cargo/vendor/matches-0.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f\", \"files\": {}}",
+        "dest": "cargo/vendor/matches-0.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memmap2/memmap2-0.5.4.crate",
+        "sha256": "d5172b50c23043ff43dd53e51392f36519d9b35a8f3a410d30ece5d1aedd58ae",
+        "dest": "cargo/vendor/memmap2-0.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d5172b50c23043ff43dd53e51392f36519d9b35a8f3a410d30ece5d1aedd58ae\", \"files\": {}}",
+        "dest": "cargo/vendor/memmap2-0.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.5.3.crate",
+        "sha256": "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc",
+        "dest": "cargo/vendor/miniz_oxide-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc\", \"files\": {}}",
+        "dest": "cargo/vendor/miniz_oxide-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.12.0.crate",
+        "sha256": "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225",
+        "dest": "cargo/vendor/once_cell-1.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pico-args/pico-args-0.5.0.crate",
+        "sha256": "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315",
+        "dest": "cargo/vendor/pico-args-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315\", \"files\": {}}",
+        "dest": "cargo/vendor/pico-args-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/png/png-0.17.5.crate",
+        "sha256": "dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba",
+        "dest": "cargo/vendor/png-0.17.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba\", \"files\": {}}",
+        "dest": "cargo/vendor/png-0.17.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rctree/rctree-0.4.0.crate",
+        "sha256": "9ae028b272a6e99d9f8260ceefa3caa09300a8d6c8d2b2001316474bc52122e9",
+        "dest": "cargo/vendor/rctree-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9ae028b272a6e99d9f8260ceefa3caa09300a8d6c8d2b2001316474bc52122e9\", \"files\": {}}",
+        "dest": "cargo/vendor/rctree-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rgb/rgb-0.8.32.crate",
+        "sha256": "e74fdc210d8f24a7dbfedc13b04ba5764f5232754ccebfdf5fff1bad791ccbc6",
+        "dest": "cargo/vendor/rgb-0.8.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e74fdc210d8f24a7dbfedc13b04ba5764f5232754ccebfdf5fff1bad791ccbc6\", \"files\": {}}",
+        "dest": "cargo/vendor/rgb-0.8.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/roxmltree/roxmltree-0.14.1.crate",
+        "sha256": "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b",
+        "dest": "cargo/vendor/roxmltree-0.14.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b\", \"files\": {}}",
+        "dest": "cargo/vendor/roxmltree-0.14.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustybuzz/rustybuzz-0.5.1.crate",
+        "sha256": "a617c811f5c9a7060fe511d35d13bf5b9f0463ce36d63ce666d05779df2b4eba",
+        "dest": "cargo/vendor/rustybuzz-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a617c811f5c9a7060fe511d35d13bf5b9f0463ce36d63ce666d05779df2b4eba\", \"files\": {}}",
+        "dest": "cargo/vendor/rustybuzz-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/safe_arch/safe_arch-0.5.2.crate",
+        "sha256": "c1ff3d6d9696af502cc3110dacce942840fb06ff4514cad92236ecc455f2ce05",
+        "dest": "cargo/vendor/safe_arch-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c1ff3d6d9696af502cc3110dacce942840fb06ff4514cad92236ecc455f2ce05\", \"files\": {}}",
+        "dest": "cargo/vendor/safe_arch-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/simplecss/simplecss-0.2.1.crate",
+        "sha256": "a11be7c62927d9427e9f40f3444d5499d868648e2edbc4e2116de69e7ec0e89d",
+        "dest": "cargo/vendor/simplecss-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a11be7c62927d9427e9f40f3444d5499d868648e2edbc4e2116de69e7ec0e89d\", \"files\": {}}",
+        "dest": "cargo/vendor/simplecss-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/siphasher/siphasher-0.3.10.crate",
+        "sha256": "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de",
+        "dest": "cargo/vendor/siphasher-0.3.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de\", \"files\": {}}",
+        "dest": "cargo/vendor/siphasher-0.3.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smallvec/smallvec-1.8.0.crate",
+        "sha256": "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83",
+        "dest": "cargo/vendor/smallvec-1.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83\", \"files\": {}}",
+        "dest": "cargo/vendor/smallvec-1.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/svgtypes/svgtypes-0.8.1.crate",
+        "sha256": "cc802f68b144cdf4d8ff21301f9a7863e837c627fde46537e29c05e8a18c85c1",
+        "dest": "cargo/vendor/svgtypes-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc802f68b144cdf4d8ff21301f9a7863e837c627fde46537e29c05e8a18c85c1\", \"files\": {}}",
+        "dest": "cargo/vendor/svgtypes-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tiny-skia/tiny-skia-0.6.5.crate",
+        "sha256": "78b3e1db967020dd509b49cecc024025beba2b1b6cf204618610ba266269d6b9",
+        "dest": "cargo/vendor/tiny-skia-0.6.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"78b3e1db967020dd509b49cecc024025beba2b1b6cf204618610ba266269d6b9\", \"files\": {}}",
+        "dest": "cargo/vendor/tiny-skia-0.6.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.15.1.crate",
+        "sha256": "42d4b50cba812f0f04f0707bb6a0eaa5fae4ae05d90fc2a377998d2f21e77a1c",
+        "dest": "cargo/vendor/ttf-parser-0.15.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"42d4b50cba812f0f04f0707bb6a0eaa5fae4ae05d90fc2a377998d2f21e77a1c\", \"files\": {}}",
+        "dest": "cargo/vendor/ttf-parser-0.15.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-bidi/unicode-bidi-0.3.8.crate",
+        "sha256": "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992",
+        "dest": "cargo/vendor/unicode-bidi-0.3.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-bidi-0.3.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-bidi-mirroring/unicode-bidi-mirroring-0.1.0.crate",
+        "sha256": "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694",
+        "dest": "cargo/vendor/unicode-bidi-mirroring-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-bidi-mirroring-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-ccc/unicode-ccc-0.1.2.crate",
+        "sha256": "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1",
+        "dest": "cargo/vendor/unicode-ccc-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-ccc-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-general-category/unicode-general-category-0.4.0.crate",
+        "sha256": "07547e3ee45e28326cc23faac56d44f58f16ab23e413db526debce3b0bfd2742",
+        "dest": "cargo/vendor/unicode-general-category-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"07547e3ee45e28326cc23faac56d44f58f16ab23e413db526debce3b0bfd2742\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-general-category-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-script/unicode-script-0.5.4.crate",
+        "sha256": "58dd944fd05f2f0b5c674917aea8a4df6af84f2d8de3fe8d988b95d28fb8fb09",
+        "dest": "cargo/vendor/unicode-script-0.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"58dd944fd05f2f0b5c674917aea8a4df6af84f2d8de3fe8d988b95d28fb8fb09\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-script-0.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-vo/unicode-vo-0.1.0.crate",
+        "sha256": "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94",
+        "dest": "cargo/vendor/unicode-vo-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-vo-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/weezl/weezl-0.1.6.crate",
+        "sha256": "9c97e489d8f836838d497091de568cf16b117486d529ec5579233521065bd5e4",
+        "dest": "cargo/vendor/weezl-0.1.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9c97e489d8f836838d497091de568cf16b117486d529ec5579233521065bd5e4\", \"files\": {}}",
+        "dest": "cargo/vendor/weezl-0.1.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xmlparser/xmlparser-0.13.3.crate",
+        "sha256": "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8",
+        "dest": "cargo/vendor/xmlparser-0.13.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8\", \"files\": {}}",
+        "dest": "cargo/vendor/xmlparser-0.13.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xmlwriter/xmlwriter-0.1.0.crate",
+        "sha256": "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9",
+        "dest": "cargo/vendor/xmlwriter-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9\", \"files\": {}}",
+        "dest": "cargo/vendor/xmlwriter-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "inline",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n",
+        "dest": "cargo",
+        "dest-filename": "config"
+    }
+]

--- a/com.github.themix_project.Oomox.json
+++ b/com.github.themix_project.Oomox.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.themix_project.Oomox",
     "runtime": "org.gnome.Sdk",
-    "runtime-version": "3.38",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
     "command": "oomox-gui",
@@ -31,26 +31,24 @@
         {
             "name": "resvg",
             "buildsystem": "simple",
-            "build-options": {
-                "append-path": "/usr/lib/sdk/rust-stable/bin"
-            },
             "build-commands": [
-                "export CARGO_HOME=$(pwd)/cargo_home ; for dir in capi tools/{render,u}svg; do ( cd $dir ; if grep -q cairo-backend Cargo.toml; then cargo build --release --features='cairo-backend' ; else cargo build --release ; fi ) done",
-                "install -Dm755 target/release/rendersvg /app/bin/rendersvg",
+                "cargo build --workspace --frozen --release --all-features",
+                "install -Dm755 target/release/resvg /app/bin/resvg",
                 "install -Dm755 target/release/libresvg.so /app/lib/libresvg.so",
-                "install -Dm644 capi/include/resvg.h /app/include/resvg.h"
+                "install -Dm644 c-api/resvg.h /app/include/resvg.h"
             ],
+            "build-options": {
+                "append-path": "/usr/lib/sdk/rust-stable/bin",
+                "env" : {
+                    "CARGO_HOME" : "/run/build/resvg/cargo"
+                }
+            },
             "sources": [
+                "cargo-sources.json",
                 {
                     "type": "archive",
-                    "url": "https://github.com/RazrFalcon/resvg/archive/v0.5.0.tar.gz",
-                    "sha256": "f9d0dc31de9b6f516c0c5350f22142ab8af6a2d957a729494bb403cff32ba611"
-                },
-                {
-                    "type": "archive",
-                    "url": "https://github.com/actionless/_flatpak_helpers/releases/download/0.5.0/cargo_home.tar.bz2",
-                    "sha256": "0548150c212dc65ba9f88b8071192cf2e113bfd2ea807e8ac482effcdc8072ce",
-                    "dest": "./cargo_home/"
+                    "url": "https://github.com/RazrFalcon/resvg/releases/download/v0.23.0/resvg-0.23.0.tar.xz",
+                    "sha256": "557de89846d1aab06f9261d1d661a64cc35ad7037ab56e49eb2a81f10487f8f5"
                 }
             ]
         },
@@ -62,19 +60,18 @@
                     "i386": {
                         "env": {
                             "MAX_CONCURRENCY": "1"
+                                }
+                            }
                         }
-                    }
-                }
             },
             "build-commands": [
-                "install -d ${FLATPAK_DEST}/lib/python3.5/site-packages/",
-                "python3 setup.py install --prefix=${FLATPAK_DEST}"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow\" --no-build-isolation"
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://files.pythonhosted.org/packages/d3/c4/b45b9c0d549f482dd072055e2d3ced88f3b977f7b87c7a990228b20e7da1/Pillow-5.2.0.tar.gz",
-                    "sha256": "f8b3d413c5a8f84b12cd4c5df1d8e211777c9852c6be3ee9c094b626644d3eab"
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/8c/92/2975b464d9926dc667020ed1abfa6276e68c3571dcb77e43347e15ee9eed/Pillow-9.2.0.tar.gz",
+                    "sha256": "75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04"
                 }
             ]
         },
@@ -91,14 +88,13 @@
                 }
             },
             "build-commands": [
-                "install -d ${FLATPAK_DEST}/lib/python3.5/site-packages/",
-                "python3 setup.py install --root=${FLATPAK_DEST} --optimize=1"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"colorthief\" --no-build-isolation"
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/fengsp/color-thief-py/archive/0.2.1.tar.gz",
-                    "sha256": "f2c47cad43809048adb9be1e4e63519d32e3b68532e8f0ab7bf46a58ddf7d099"
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/56/18/be03b7058e65f9df479b14e7af4e73945ce311e07aaad45cf2536e14791a/colorthief-0.2.1-py2.py3-none-any.whl",
+                    "sha256": "b04fc8ce5cf9c888768745e29cb19b7b688d5711af6fba26e8057debabec56b9"
                 }
             ]
         },
@@ -115,14 +111,59 @@
                 }
             },
             "build-commands": [
-                "install -d ${FLATPAK_DEST}/lib/python3.5/site-packages/",
-                "python3 setup.py install --root=${FLATPAK_DEST}"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"haishoku\" --no-build-isolation"
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/LanceGin/haishoku/archive/v1.1.7.tar.gz",
-                    "sha256": "4f34043f5509e18b60411050b40596f9510193ae8dca5146f7e82cc0730536b8"
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d1/9d/5d52b35d4aef716266e812d8c6df9702e31de4499a4cbe567c0e71cee225/haishoku-1.1.8-py3-none-any.whl",
+                    "sha256": "c505b8154aa41c98748059860033d47c1409330c5ac4fdbc90378223ebb996b4"
+                }
+            ]
+        },
+        {
+            "name": "python3-pystache",
+            "buildsystem": "simple",
+            "build-options": {
+                "arch": {
+                    "i386": {
+                        "env": {
+                            "MAX_CONCURRENCY": "1"
+                        }
+                    }
+                }
+            },
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pystache\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/3f/e7/8750ba6c6101d6aa5ceeb20c013adf2c6f3554a12c71d75654b468404bfa/pystache-0.6.0.tar.gz",
+                    "sha256": "93bf92b2149a4c4b58d12142e2c4c6dd5c08d89e4c95afccd4b6efe2ee1d470d"
+                }
+            ]
+        },
+        {
+            "name": "python3-pyyaml",
+            "buildsystem": "simple",
+            "build-options": {
+                "arch": {
+                    "i386": {
+                        "env": {
+                            "MAX_CONCURRENCY": "1"
+                        }
+                    }
+                }
+            },
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyyaml\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz",
+                    "sha256": "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"
                 }
             ]
         },
@@ -136,14 +177,14 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/sass/libsass/archive/3.4.7.tar.gz",
-                    "sha256": "855c40528b897d06ae4d24606c2db3cd09bb38de5b46b28e835f9d4fd4d7ab95",
+                    "url": "https://github.com/sass/libsass/archive/refs/tags/3.6.5.tar.gz",
+                    "sha256": "89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582",
                     "dest": "./deps/libsass/"
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/sass/sassc/archive/3.4.2.tar.gz",
-                    "sha256": "ad805f2d404d17cf2980c8079a7413cd58d2f2085120167997b85420a722e079",
+                    "url": "https://github.com/sass/sassc/archive/refs/tags/3.6.2.tar.gz",
+                    "sha256": "608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03",
                     "dest": "./deps/sassc/"
                 }
             ]
@@ -182,8 +223,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.imagemagick.org/download/releases/ImageMagick-7.0.8-68.tar.xz",
-                    "sha256": "3639baa6ceb5db38b1b48a4b917f90fe007ca7edca1f7894d5555a0bc746305a"
+                    "url": "https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.0.43.tar.gz",
+                    "sha256": "62eccb3e8c89acc66c2b10a2bea843b6659a2ddce275c7d2ffee8c34af6114fd"
                 }
             ]
         },
@@ -202,7 +243,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/themix-project/oomox.git",
-                    "tag": "1.13.3"
+                    "tag": "1.14"
                 }
             ]
         }

--- a/com.github.themix_project.Oomox.json
+++ b/com.github.themix_project.Oomox.json
@@ -32,18 +32,18 @@
         {
             "name": "resvg",
             "buildsystem": "simple",
-            "build-commands": [
-                "cargo build --workspace --frozen --release --all-features",
-                "install -Dm755 target/release/resvg /app/bin/resvg",
-                "install -Dm755 target/release/libresvg.so /app/lib/libresvg.so",
-                "install -Dm644 c-api/resvg.h /app/include/resvg.h"
-            ],
             "build-options": {
                 "append-path": "/usr/lib/sdk/rust-stable/bin",
                 "env" : {
                     "CARGO_HOME" : "/run/build/resvg/cargo"
                 }
             },
+            "build-commands": [
+                "cargo build --workspace --frozen --release --all-features",
+                "install -Dm755 target/release/resvg /app/bin/resvg",
+                "install -Dm755 target/release/libresvg.so /app/lib/libresvg.so",
+                "install -Dm644 c-api/resvg.h /app/include/resvg.h"
+            ],
             "sources": [
                 "cargo-sources.json",
                 {

--- a/com.github.themix_project.Oomox.json
+++ b/com.github.themix_project.Oomox.json
@@ -189,11 +189,7 @@
             "buildsystem": "simple",
             "build-commands": [
                 "make DESTDIR=/ PREFIX=/app APPDIR=/app/opt/oomox install_gui install_theme_arc install_theme_oomox install_theme_materia install_import_images install_plugin_base16 install_icons_archdroid install_icons_gnomecolors install_icons_numix install_icons_papirus install_icons_suruplus install_icons_suruplus_aspromauros",
-                "python3 -O -m compileall /app/opt/oomox/oomox_gui",
-                "mkdir -p /app/usr/share/",
-                "ln -s /app/share/applications /app/usr/share/applications",
-                "ln -s /app/share/appdata /app/usr/share/appdata",
-                "ln -s /app/share/icons /app/usr/share/icons"
+                "python3 -O -m compileall /app/opt/oomox/oomox_gui"
             ],
             "sources": [
                 {

--- a/com.github.themix_project.Oomox.json
+++ b/com.github.themix_project.Oomox.json
@@ -56,15 +56,6 @@
         {
             "name": "python3-pillow",
             "buildsystem": "simple",
-            "build-options": {
-                "arch": {
-                    "i386": {
-                        "env": {
-                            "MAX_CONCURRENCY": "1"
-                                }
-                            }
-                        }
-            },
             "build-commands": [
                 "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow\" --no-build-isolation"
             ],
@@ -79,15 +70,6 @@
         {
             "name": "python3-colorthief",
             "buildsystem": "simple",
-            "build-options": {
-                "arch": {
-                    "i386": {
-                        "env": {
-                            "MAX_CONCURRENCY": "1"
-                        }
-                    }
-                }
-            },
             "build-commands": [
                 "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"colorthief\" --no-build-isolation"
             ],
@@ -102,15 +84,6 @@
         {
             "name": "python3-haishoku",
             "buildsystem": "simple",
-            "build-options": {
-                "arch": {
-                    "i386": {
-                        "env": {
-                            "MAX_CONCURRENCY": "1"
-                        }
-                    }
-                }
-            },
             "build-commands": [
                 "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"haishoku\" --no-build-isolation"
             ],
@@ -125,15 +98,6 @@
         {
             "name": "python3-pystache",
             "buildsystem": "simple",
-            "build-options": {
-                "arch": {
-                    "i386": {
-                        "env": {
-                            "MAX_CONCURRENCY": "1"
-                        }
-                    }
-                }
-            },
             "build-commands": [
                 "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pystache\" --no-build-isolation"
             ],
@@ -148,15 +112,6 @@
         {
             "name": "python3-pyyaml",
             "buildsystem": "simple",
-            "build-options": {
-                "arch": {
-                    "i386": {
-                        "env": {
-                            "MAX_CONCURRENCY": "1"
-                        }
-                    }
-                }
-            },
             "build-commands": [
                 "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyyaml\" --no-build-isolation"
             ],

--- a/com.github.themix_project.Oomox.json
+++ b/com.github.themix_project.Oomox.json
@@ -133,14 +133,14 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/sass/libsass/archive/refs/tags/3.6.5.tar.gz",
-                    "sha256": "89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582",
+                    "url": "https://github.com/sass/libsass/archive/refs/tags/3.6.1.tar.gz",
+                    "sha256": "18d6e866ba2430cccae2551f384aca253a84592c692ce7146550f1d4f273b7d7",
                     "dest": "./deps/libsass/"
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/sass/sassc/archive/refs/tags/3.6.2.tar.gz",
-                    "sha256": "608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03",
+                    "url": "https://github.com/sass/sassc/archive/refs/tags/3.6.1.tar.gz",
+                    "sha256": "8cee391c49a102b4464f86fc40c4ceac3a2ada52a89c4c933d8348e3e4542a60",
                     "dest": "./deps/sassc/"
                 }
             ]

--- a/com.github.themix_project.Oomox.json
+++ b/com.github.themix_project.Oomox.json
@@ -9,7 +9,8 @@
         "--share=ipc",
         "--filesystem=~/.themes:create",
         "--filesystem=~/.icons:create",
-        "--socket=x11"
+        "--socket=fallback-x11",
+        "--socket=wayland"
     ],
     "modules": [
         {

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "skip-appstream-check": true
-}


### PR DESCRIPTION
- Update resvg to 0.23.0, add cargo manifest and add new build commands
- Update Pillow to 9.2.0, haishoku to 1.1.8
- Add pystache and pyyaml for Base16 format
- Update libsass to 3.6.1 and sassc to 3.6.1
- Update ImageMagick to 7.1.0.43
- Update oomox to 1.14

This built and ran fine locally but I don't use the app, so needs testing to see if it still works. 

It ran fine in native wayland, so I added support for it. If there are issues or wayland is unsupported entirely I can drop that change. :)

Ping @actionless, please review when you have time, thanks!