### PR TITLE
Mark Oomox as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This flatpak is no longer maintained."
+}


### PR DESCRIPTION
> This **flatpak** is no longer maintained

> **End-of-life runtime transition**: 
> To focus our resources on maintaining high-quality, up-to-date runtimes, we'll be completing the removal of several end-of-life runtimes in January 2026. Apps using runtimes older than freedesktop-sdk 22.08, GNOME 45, KDE 5.15-22.08 or KDE 6.6 will be marked as EOL shortly. 

Source: https://docs.flathub.org/blog/enhanced-license-compliance-tools

More information:
- https://github.com/flathub/com.github.themix_project.Oomox/issues/13
- https://github.com/themix-project/themix-gui/issues/523